### PR TITLE
Update BowTeleportationListener.java

### DIFF
--- a/src/me/lightcab/BowTeleportationListener.java
+++ b/src/me/lightcab/BowTeleportationListener.java
@@ -9,20 +9,15 @@ import org.bukkit.event.entity.ProjectileHitEvent;
 
 public class BowTeleportationListener implements Listener {
 
-    BowTeleportationMain plugin;
-
-    public BowTeleportationListener(BowTeleportationMain instance) {
-        this.plugin = instance;
-    }
+    BowTeleportationMain plugin = BowTeleportationMain.instance;
 
     @EventHandler
-    public void onProjectileHitEvent(ProjectileHitEvent e) {
-        Player p = (Player) e.getEntity().getShooter();
-        Entity entity = e.getEntity();
-        if (plugin.bowtpPlayers.contains(p.getName())) {
-            if (entity instanceof Arrow) {
-                p.teleport(entity.getLocation());
-            }
+    public void onProjectileHitEvent(ProjectileHitEvent event) {
+        Entity entity = event.getEntity();
+        ProjectileSource shooter = entity.getShooter();
+        if (shooter instanceof Player && entity instanceof Arrow) {
+            Player player = (Player) shooter;
+            if (plugin.bowtpPlayers.contains(player.getUUID()) player.teleport(entity.getLocation());
         }
     }
 }


### PR DESCRIPTION
"Player p = (Player) e.getEntity().getShooter();" can throw errors. First check if it's a player. (It could be skeleton or dispenser.
One letter variable names aren't usually a good idea.
Shorter code is usually better (Although sometimes longer code results in better readability so don't stand by this rule).